### PR TITLE
adding zIndex to popoverProps in InputWithOptions

### DIFF
--- a/packages/wix-style-react/src/InputWithOptions/InputWithOptions.js
+++ b/packages/wix-style-react/src/InputWithOptions/InputWithOptions.js
@@ -573,6 +573,7 @@ InputWithOptions.propTypes = {
       'left-start',
     ]),
     dynamicWidth: PropTypes.bool,
+    zIndex: PropTypes.number
   }),
 };
 


### PR DESCRIPTION
### 🔦 Summary

Allowing to set zIndex in autocomplete. This fixes the scenario when you append the popover to the window (default zIndex === 1000) and set the autocomplete inside a modal (zIndex > 1000) so this enables manual setting of zIndex

